### PR TITLE
Experiment/work with vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "ripemd",
  "secp256k1",
  "sha2",
+ "threadpool",
 ]
 
 [[package]]
@@ -226,6 +227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +252,16 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -406,6 +423,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ secp256k1 = { version = "0.29.1", features = ["rand-std"] }
 sha2 = "0.10.8"
 ripemd = "0.1.3"
 hmac = "0.12.1"
+threadpool = "1.8.1"
+
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,3 @@ sha2 = "0.10.8"
 ripemd = "0.1.3"
 hmac = "0.12.1"
 threadpool = "1.8.1"
-
-
-[profile.release]
-debug = true

--- a/src/bitcoin_address_helper.rs
+++ b/src/bitcoin_address_helper.rs
@@ -32,6 +32,20 @@ impl BitcoinAddressHelper {
         self.base58_encode(&result)
     }
 
+    pub fn get_pubkey_hash_from_address(&self, address: String) -> Option<[u8; 20]> {
+        let address_bytes = bs58::decode(address).into_vec().unwrap();
+        if address_bytes.len() != 25 {
+            return None;
+        }
+        let pubkey_hash = address_bytes
+            .iter()
+            .skip(1)
+            .take(20)
+            .cloned()
+            .collect::<Vec<u8>>();
+        Some(pubkey_hash.try_into().unwrap())
+    }
+
     fn base58_encode(&self, data: &[u8]) -> String {
         bs58::encode(data).into_string()
     }

--- a/src/extended_public_key_deriver.rs
+++ b/src/extended_public_key_deriver.rs
@@ -23,6 +23,14 @@ pub struct ExtendedPublicKeyDeriver {
     thread_pool: ThreadPool,
 }
 
+impl Drop for ExtendedPublicKeyDeriver {
+    fn drop(&mut self) {
+        if let Ok(mut cache) = self.derivation_cache.write() {
+            cache.clear();
+        }
+    }
+}
+
 const MAX_CACHE_SIZE: usize = 100_00000;
 
 impl ExtendedPubKey {

--- a/src/extended_public_key_deriver.rs
+++ b/src/extended_public_key_deriver.rs
@@ -7,6 +7,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{mpsc, Arc, RwLock};
 use threadpool::ThreadPool;
 
+const MAX_CACHE_SIZE: usize = 100_00000;
+const MAX_CACHE_PATHS_RATIO: usize = 10;
+
 #[derive(Clone, Debug)]
 pub struct ExtendedPubKey {
     pub public_key: PublicKey,
@@ -14,31 +17,30 @@ pub struct ExtendedPubKey {
     pub depth: u8,
 }
 
-pub struct ExtendedPublicKeyDeriver {
-    xpub: String,
-    pub non_hardening_max_index: u32,
-    derivation_cache: Arc<RwLock<HashMap<Vec<u32>, ExtendedPubKey>>>,
-    secp: Secp256k1<secp256k1::All>,
-    base_xpub: Option<ExtendedPubKey>,
-    thread_pool: ThreadPool,
-}
-
-impl Drop for ExtendedPublicKeyDeriver {
-    fn drop(&mut self) {
-        if let Ok(mut cache) = self.derivation_cache.write() {
-            cache.clear();
-        }
-    }
-}
-
-const MAX_CACHE_SIZE: usize = 100_00000;
-
 impl ExtendedPubKey {
     pub fn from_str(xpub: &str) -> Result<Self, String> {
         if !xpub.starts_with("xpub") {
             return Err("Invalid xpub format: must start with 'xpub'".to_string());
         }
 
+        let data = Self::decode_base58(xpub)?;
+        let (payload, checksum) = data.split_at(78);
+        Self::verify_checksum(payload, checksum)?;
+        
+        let mut chain_code = [0u8; 32];
+        chain_code.copy_from_slice(&payload[13..45]);
+
+        let public_key = PublicKey::from_slice(&payload[45..78])
+            .map_err(|e| format!("Invalid public key: {}", e))?;
+
+        Ok(ExtendedPubKey {
+            public_key,
+            chain_code,
+            depth: payload[4],
+        })
+    }
+
+    fn decode_base58(xpub: &str) -> Result<Vec<u8>, String> {
         let data = bs58::decode(xpub)
             .into_vec()
             .map_err(|e| format!("Failed to decode base58: {}", e))?;
@@ -47,9 +49,10 @@ impl ExtendedPubKey {
             return Err(format!("Invalid xpub length: {}", data.len()));
         }
 
-        let payload = &data[0..78];
-        let checksum = &data[78..82];
+        Ok(data)
+    }
 
+    fn verify_checksum(payload: &[u8], checksum: &[u8]) -> Result<(), String> {
         let mut hasher = Sha256::new();
         hasher.update(payload);
         let first_hash = hasher.finalize();
@@ -65,21 +68,7 @@ impl ExtendedPubKey {
                 &second_hash[0..4]
             ));
         }
-
-        let mut chain_code = [0u8; 32];
-        chain_code.copy_from_slice(&payload[13..45]);
-
-        let public_key = PublicKey::from_slice(&payload[45..78])
-            .map_err(|e| format!("Invalid public key: {}", e))?;
-
-        let mut parent_fingerprint = [0u8; 4];
-        parent_fingerprint.copy_from_slice(&payload[5..9]);
-
-        Ok(ExtendedPubKey {
-            public_key,
-            chain_code,
-            depth: payload[4],
-        })
+        Ok(())
     }
 
     pub fn derive_child(
@@ -87,6 +76,20 @@ impl ExtendedPubKey {
         secp: &Secp256k1<secp256k1::All>,
         index: u32,
     ) -> Result<Self, String> {
+        let (il, ir) = self.generate_child_keys(index)?;
+        let child_pubkey = self.compute_child_pubkey(secp, &il)?;
+
+        let mut chain_code = [0u8; 32];
+        chain_code.copy_from_slice(ir.as_slice());
+
+        Ok(ExtendedPubKey {
+            public_key: child_pubkey,
+            chain_code,
+            depth: self.depth + 1,
+        })
+    }
+
+    fn generate_child_keys(&self, index: u32) -> Result<(Vec<u8>, Vec<u8>), String> {
         use hmac::{Hmac, Mac};
         type HmacSha512 = Hmac<sha2::Sha512>;
 
@@ -99,132 +102,54 @@ impl ExtendedPubKey {
         hmac.update(&data);
         let result = hmac.finalize().into_bytes();
 
-        let il = &result[0..32];
-        let ir = &result[32..];
+        Ok((result[0..32].to_vec(), result[32..].to_vec()))
+    }
 
-        let tweak =
-            secp256k1::SecretKey::from_slice(il).map_err(|e| format!("Invalid tweak: {}", e))?;
+    fn compute_child_pubkey(
+        &self,
+        secp: &Secp256k1<secp256k1::All>,
+        il: &[u8],
+    ) -> Result<PublicKey, String> {
+        let tweak = secp256k1::SecretKey::from_slice(il)
+            .map_err(|e| format!("Invalid tweak: {}", e))?;
 
-        let child_pubkey = self
-            .public_key
+        self.public_key
             .combine(&PublicKey::from_secret_key(secp, &tweak))
-            .map_err(|e| format!("Failed to derive child key: {}", e))?;
-
-        let mut chain_code = [0u8; 32];
-        chain_code.copy_from_slice(ir);
-
-        Ok(ExtendedPubKey {
-            public_key: child_pubkey,
-            chain_code,
-            depth: self.depth + 1,
-        })
+            .map_err(|e| format!("Failed to derive child key: {}", e))
     }
 }
 
-impl ExtendedPublicKeyDeriver {
-    pub fn new(xpub: &str) -> Self {
-        let base = ExtendedPubKey::from_str(xpub).ok();
+// Core derivation logic that works only with cache
+pub struct ExtendedPubKeyCore {
+    base_xpub: ExtendedPubKey,
+    derivation_cache: Arc<RwLock<HashMap<Vec<u32>, ExtendedPubKey>>>,
+    secp: Secp256k1<secp256k1::All>,
+    non_hardening_max_index: u32,
+}
 
-        let num_threads = std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or(4);
-
+impl ExtendedPubKeyCore {
+    pub fn new(base_xpub: ExtendedPubKey, cache: Arc<RwLock<HashMap<Vec<u32>, ExtendedPubKey>>>) -> Self {
         Self {
-            xpub: xpub.to_string(),
-            non_hardening_max_index: 0x7FFFFFFF,
-            derivation_cache: Arc::new(RwLock::new(HashMap::new())),
+            base_xpub,
+            derivation_cache: cache,
             secp: Secp256k1::new(),
-            base_xpub: base,
-            thread_pool: ThreadPool::new(num_threads),
+            non_hardening_max_index: 0x7FFFFFFF,
         }
     }
 
-    pub fn get_pubkeys_hash_160(&self, paths: &[Vec<u32>]) -> Result<Vec<[u8; 20]>, String> {
-        let mut paths_to_cache: HashSet<Vec<u32>> = HashSet::new();
-        {
-            let cache_read = self.derivation_cache.read().map_err(|e| e.to_string())?;
-            for path in paths {
-                if path.len() > 1 {
-                    for i in 1..path.len() {
-                        let ancestor = path[0..i].to_vec();
-                        if !cache_read.contains_key(&ancestor) {
-                            paths_to_cache.insert(ancestor);
-                        }
-                    }
-                }
-            }
-            if cache_read.len() + paths_to_cache.len() >= MAX_CACHE_SIZE {
-                drop(cache_read);
-                self.derivation_cache
-                    .write()
-                    .map_err(|e| e.to_string())?
-                    .clear();
-            }
-        }
-
-        if paths_to_cache.len() > MAX_CACHE_SIZE / 10 {
-            println!("need to cache {} paths", paths_to_cache.len());
-            panic!("Cache size exceeded");
-        }
-
-        let mut ordered_paths: Vec<_> = paths_to_cache.into_iter().collect();
-        ordered_paths.sort_by_key(|p| p.len());
-        for path_to_cache in ordered_paths {
-            let derived = self.get_derived_xpub(&path_to_cache)?;
-            self.derivation_cache
-                .write()
-                .map_err(|e| e.to_string())?
-                .insert(path_to_cache, derived);
-        }
-
-        let chunk_size =
-            (paths.len() + self.thread_pool.max_count() - 1) / self.thread_pool.max_count();
-        let (tx, rx) = mpsc::channel();
-
-        for chunk in paths.chunks(chunk_size) {
-            let chunk_paths = chunk.to_vec();
-            let xpub = self.xpub.clone();
-            let base_xpub = self.base_xpub.clone();
-            let tx = tx.clone();
-            let non_hardening_max_index = self.non_hardening_max_index;
-
-            self.thread_pool.execute(move || {
-                let mut results = Vec::with_capacity(chunk_paths.len());
-                let mut deriver = ExtendedPublicKeyDeriver {
-                    xpub,
-                    non_hardening_max_index,
-                    derivation_cache: Arc::new(RwLock::new(HashMap::new())), // Thread-local cache
-                    secp: Secp256k1::new(),
-                    base_xpub,
-                    thread_pool: ThreadPool::new(1), // Dummy pool for thread-local instance
-                };
-
-                for path in chunk_paths {
-                    match deriver.get_pubkey_hash_160(&path) {
-                        Ok(hash) => results.push(Ok(hash)),
-                        Err(e) => results.push(Err(e)),
-                    }
-                }
-                tx.send(results).unwrap();
-            });
-        }
-
-        drop(tx);
-
-        let mut all_results = Vec::with_capacity(paths.len());
-        while let Ok(chunk_results) = rx.recv() {
-            for result in chunk_results {
-                all_results.push(result?);
-            }
-        }
-
-        Ok(all_results)
-    }
-
-    pub fn get_pubkey_hash_160(&mut self, path: &[u32]) -> Result<[u8; 20], String> {
+    pub fn get_pubkey_hash_160(&self, path: &[u32]) -> Result<[u8; 20], String> {
         let pubkey = self.get_pubkey(path)?;
+        self.compute_hash160(&pubkey)
+    }
+
+    pub fn get_pubkey(&self, path: &[u32]) -> Result<[u8; 33], String> {
+        let derived_xpub = self.get_derived_xpub(path)?;
+        Ok(derived_xpub.public_key.serialize())
+    }
+
+    fn compute_hash160(&self, pubkey: &[u8]) -> Result<[u8; 20], String> {
         let mut hasher = Sha256::new();
-        hasher.update(&pubkey);
+        hasher.update(pubkey);
         let hash = hasher.finalize();
 
         let mut ripemd_hasher = Ripemd160::new();
@@ -236,29 +161,8 @@ impl ExtendedPublicKeyDeriver {
         Ok(result)
     }
 
-    pub fn get_pubkey(&mut self, path: &[u32]) -> Result<[u8; 33], String> {
-        let derived_xpub = self.get_derived_xpub(path)?;
-        Ok(derived_xpub.public_key.serialize())
-    }
-
     fn get_from_cache(&self, path: &[u32]) -> Option<ExtendedPubKey> {
         self.derivation_cache.read().ok()?.get(path).cloned()
-    }
-
-    fn store_in_cache(&self, path: Vec<u32>, xpub: ExtendedPubKey) {
-        if let Ok(mut cache) = self.derivation_cache.write() {
-            if cache.len() >= MAX_CACHE_SIZE {
-                cache.clear();
-            }
-            cache.insert(path, xpub);
-        }
-    }
-
-    fn get_base_xpub(&self) -> Result<ExtendedPubKey, String> {
-        if let Some(ref base) = self.base_xpub {
-            return Ok(base.clone());
-        }
-        ExtendedPubKey::from_str(&self.xpub)
     }
 
     fn derive_single_step(
@@ -274,36 +178,162 @@ impl ExtendedPublicKeyDeriver {
 
     fn get_derived_xpub(&self, path: &[u32]) -> Result<ExtendedPubKey, String> {
         if path.is_empty() {
-            return self.get_base_xpub();
+            return Ok(self.base_xpub.clone());
         }
 
-        // Try to get from cache using the full path
         if let Some(cached) = self.get_from_cache(path) {
-            return Ok(cached.clone());
+            return Ok(cached);
         }
 
+        self.derive_path(path)
+    }
+
+    fn derive_path(&self, path: &[u32]) -> Result<ExtendedPubKey, String> {
         let mut current_path = Vec::with_capacity(path.len());
-        let mut current_xpub = self.get_base_xpub()?;
+        let mut current_xpub = self.base_xpub.clone();
 
         for (i, &index) in path.iter().enumerate() {
             current_path.push(index);
 
-            // Only check cache for non-final paths to avoid unnecessary lookups
             if i < path.len() - 1 {
                 if let Some(cached) = self.get_from_cache(&current_path) {
-                    current_xpub = cached.clone();
+                    current_xpub = cached;
                     continue;
                 }
             }
 
             current_xpub = self.derive_single_step(&current_xpub, index)?;
-
-            // Cache all intermediate paths
-            if i < path.len() - 1 {
-                self.store_in_cache(current_path.clone(), current_xpub.clone());
-            }
         }
 
         Ok(current_xpub)
     }
 }
+
+// Orchestrator that handles threading and cache management
+pub struct ExtendedPublicKeyDeriver {
+    derivation_cache: Arc<RwLock<HashMap<Vec<u32>, ExtendedPubKey>>>,
+    thread_pool: ThreadPool,
+    base_xpub: ExtendedPubKey,
+}
+
+impl ExtendedPublicKeyDeriver {
+    pub fn new(xpub: &str) -> Result<Self, String> {
+        let base_xpub = ExtendedPubKey::from_str(xpub)?;
+        let num_threads = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(4);
+
+        Ok(Self {
+            derivation_cache: Arc::new(RwLock::new(HashMap::new())),
+            thread_pool: ThreadPool::new(num_threads),
+            base_xpub,
+        })
+    }
+
+    pub fn get_pubkeys_hash_160(&self, paths: &[Vec<u32>]) -> Result<Vec<[u8; 20]>, String> {
+        let paths_to_cache = self.collect_ancestor_paths(paths)?;
+        self.populate_cache(&paths_to_cache)?;
+        self.process_paths_in_parallel(paths)
+    }
+
+    fn collect_ancestor_paths(&self, paths: &[Vec<u32>]) -> Result<HashSet<Vec<u32>>, String> {
+        let mut paths_to_cache = HashSet::new();
+        let cache_read = self.derivation_cache.read().map_err(|e| e.to_string())?;
+
+        for path in paths {
+            if path.len() > 1 {
+                for i in 1..path.len() {
+                    let ancestor = path[0..i].to_vec();
+                    if !cache_read.contains_key(&ancestor) {
+                        paths_to_cache.insert(ancestor);
+                    }
+                }
+            }
+        }
+
+        if cache_read.len() + paths_to_cache.len() >= MAX_CACHE_SIZE {
+            drop(cache_read);
+            self.derivation_cache
+                .write()
+                .map_err(|e| e.to_string())?
+                .clear();
+        }
+
+        if paths_to_cache.len() > MAX_CACHE_SIZE / MAX_CACHE_PATHS_RATIO {
+            println!("need to cache {} paths", paths_to_cache.len());
+            panic!("Cache size exceeded");
+        }
+
+        Ok(paths_to_cache)
+    }
+
+    fn populate_cache(&self, paths_to_cache: &HashSet<Vec<u32>>) -> Result<(), String> {
+        let core = ExtendedPubKeyCore::new(self.base_xpub.clone(), self.derivation_cache.clone());
+        let mut ordered_paths: Vec<_> = paths_to_cache.iter().collect();
+        ordered_paths.sort_by_key(|p| p.len());
+
+        for path in ordered_paths {
+            let derived = core.get_derived_xpub(path)?;
+            if let Ok(mut cache) = self.derivation_cache.write() {
+                cache.insert(path.clone(), derived);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn process_paths_in_parallel(&self, paths: &[Vec<u32>]) -> Result<Vec<[u8; 20]>, String> {
+        let chunk_size = (paths.len() + self.thread_pool.max_count() - 1) / self.thread_pool.max_count();
+        let (tx, rx) = mpsc::channel();
+
+        self.spawn_worker_threads(paths, chunk_size, tx);
+        self.collect_results(paths.len(), rx)
+    }
+
+    fn spawn_worker_threads(&self, paths: &[Vec<u32>], chunk_size: usize, tx: mpsc::Sender<Vec<Result<[u8; 20], String>>>) {
+        for chunk in paths.chunks(chunk_size) {
+            let chunk_paths = chunk.to_vec();
+            let cache = self.derivation_cache.clone();
+            let base_xpub = self.base_xpub.clone();
+            let tx = tx.clone();
+
+            self.thread_pool.execute(move || {
+                let core = ExtendedPubKeyCore::new(base_xpub, cache);
+                let mut results = Vec::with_capacity(chunk_paths.len());
+
+                for path in chunk_paths {
+                    match core.get_pubkey_hash_160(&path) {
+                        Ok(hash) => results.push(Ok(hash)),
+                        Err(e) => results.push(Err(e)),
+                    }
+                }
+                tx.send(results).unwrap();
+            });
+        }
+    }
+
+    fn collect_results(
+        &self,
+        total_paths: usize,
+        rx: mpsc::Receiver<Vec<Result<[u8; 20], String>>>,
+    ) -> Result<Vec<[u8; 20]>, String> {
+        let mut all_results = Vec::with_capacity(total_paths);
+
+        while let Ok(chunk_results) = rx.recv() {
+            for result in chunk_results {
+                all_results.push(result?);
+            }
+        }
+
+        Ok(all_results)
+    }
+}
+
+impl Drop for ExtendedPublicKeyDeriver {
+    fn drop(&mut self) {
+        if let Ok(mut cache) = self.derivation_cache.write() {
+            cache.clear();
+        }
+    }
+}
+

--- a/src/extended_public_key_path_walker.rs
+++ b/src/extended_public_key_path_walker.rs
@@ -1,20 +1,11 @@
-pub struct ExtendedPUblicKeyPathWalker {
+pub struct ExtendedPublicKeyPathWalker {
     xpub_path: Vec<u32>,
     max_depth: u32,
     first_call: bool,
     max_non_hardening_index: u32,
 }
 
-impl Iterator for ExtendedPUblicKeyPathWalker {
-    type Item = Vec<u32>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.next_path();
-        return Some(self.xpub_path.clone());
-    }
-}
-
-impl ExtendedPUblicKeyPathWalker {
+impl ExtendedPublicKeyPathWalker {
     pub fn new(initial_path: Vec<u32>, max_depth: u32) -> Self {
         for derivation in initial_path.clone() {
             if derivation > 0x7FFFFFFF {
@@ -29,26 +20,30 @@ impl ExtendedPUblicKeyPathWalker {
             max_non_hardening_index: 0x7FFFFFFF,
         }
     }
-
-    fn next_path(&mut self) {
+    pub fn get_n_next_paths(&mut self, n: usize) -> Vec<Vec<u32>> {
+        let mut paths = Vec::new();
+        let initial_path: Vec<u32> = self.xpub_path.clone();
         if self.first_call {
+            paths.push(initial_path);
             self.first_call = false;
-            return;
         }
-
-        let mut last_index = self.xpub_path.len() - 1;
-        if self.xpub_path[last_index] < self.max_depth {
-            self.xpub_path[last_index] += 1;
-        } else {
-            self.xpub_path.truncate(last_index - 1);
-            last_index = self.xpub_path.len() - 1;
-
-            if self.xpub_path[last_index] < self.max_non_hardening_index {
+        for _ in 0..(n - paths.len()) {
+            let mut last_index = self.xpub_path.len() - 1;
+            if self.xpub_path[last_index] < self.max_depth {
                 self.xpub_path[last_index] += 1;
-                self.xpub_path.extend_from_slice(&[0, 0]);
             } else {
-                self.xpub_path.extend_from_slice(&[0, 0, 0]);
+                self.xpub_path.truncate(last_index - 1);
+                last_index = self.xpub_path.len() - 1;
+
+                if self.xpub_path[last_index] < self.max_non_hardening_index {
+                    self.xpub_path[last_index] += 1;
+                    self.xpub_path.extend_from_slice(&[0, 0]);
+                } else {
+                    self.xpub_path.extend_from_slice(&[0, 0, 0]);
+                }
             }
+            paths.push(self.xpub_path.clone());
         }
+        paths
     }
 }

--- a/src/extended_public_key_path_walker.rs
+++ b/src/extended_public_key_path_walker.rs
@@ -22,9 +22,8 @@ impl ExtendedPublicKeyPathWalker {
     }
     pub fn get_n_next_paths(&mut self, n: usize) -> Vec<Vec<u32>> {
         let mut paths = Vec::new();
-        let initial_path: Vec<u32> = self.xpub_path.clone();
         if self.first_call {
-            paths.push(initial_path);
+            paths.push(self.xpub_path.clone());
             self.first_call = false;
         }
         for _ in 0..(n - paths.len()) {

--- a/src/extended_public_key_path_walker.rs
+++ b/src/extended_public_key_path_walker.rs
@@ -32,14 +32,15 @@ impl ExtendedPublicKeyPathWalker {
             if self.xpub_path[last_index] < self.max_depth {
                 self.xpub_path[last_index] += 1;
             } else {
-                self.xpub_path.truncate(last_index - 1);
-                last_index = self.xpub_path.len() - 1;
-
-                if self.xpub_path[last_index] < self.max_non_hardening_index {
-                    self.xpub_path[last_index] += 1;
-                    self.xpub_path.extend_from_slice(&[0, 0]);
+                if self.xpub_path[last_index - 2] < self.max_non_hardening_index {
+                    // [x, y, non_max_hardening, 0, max_index] -> [x, y, non_max_hardening+1, 0, 0]
+                    self.xpub_path[last_index - 2] += 1;
+                    self.xpub_path[last_index] = 0;
                 } else {
-                    self.xpub_path.extend_from_slice(&[0, 0, 0]);
+                    last_index += 1;
+                    // [x, y, max_hardening, 0, max_index] -> [x, y, max_hardening, 0, 0, 0 (new)]
+                    self.xpub_path.push(0);
+                    self.xpub_path[last_index - 1] = 0;
                 }
             }
             paths.push(self.xpub_path.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,166 +7,17 @@ mod vanity_address;
 
 use cli::Cli;
 use extended_public_key_deriver::ExtendedPublicKeyDeriver;
-use extended_public_key_path_walker::ExtendedPUblicKeyPathWalker;
+use extended_public_key_path_walker::ExtendedPublicKeyPathWalker;
 use rand;
-use state_handler::StateHandler;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
-use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use vanity_address::VanityAddress;
 
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
 const THREADS_BATCH_SIZE: usize = 1000;
 const WAIT_TIME_FOR_INITIAL_HASHRATE: u8 = 5;
 
-fn setup_worker_thread(
-    xpub: String,
-    prefix: String,
-    max_depth: u32,
-    global_generated_counter: Arc<AtomicUsize>,
-    global_found_counter: Arc<AtomicUsize>,
-    running: Arc<AtomicBool>,
-) {
-    let initial_path = vec![rand::random::<u32>() & 0x7FFFFFFF];
-    let xpub_path_walker = ExtendedPUblicKeyPathWalker::new(initial_path, max_depth);
-    let mut xpub_deriver = ExtendedPublicKeyDeriver::new(&xpub);
-    let vanity_address = VanityAddress::new(&prefix);
-    let mut state_handler = StateHandler::new(
-        Arc::clone(&global_generated_counter),
-        Arc::clone(&global_found_counter),
-        running,
-        THREADS_BATCH_SIZE,
-    );
-
-    for xpub_path in xpub_path_walker {
-        if !state_handler.is_running() {
-            return;
-        }
-        state_handler.new_generated();
-        let pubkey_hash = xpub_deriver.get_pubkey_hash_160(&xpub_path).unwrap();
-        match vanity_address.get_vanity_address(pubkey_hash) {
-            Some(address) => {
-                let xpath_path_string = xpub_path
-                    .iter()
-                    .take(xpub_path.len().saturating_sub(2))
-                    .map(|p| p.to_string())
-                    .collect::<Vec<String>>()
-                    .join("/");
-                let receive_address = xpub_path[xpub_path.len() - 1];
-                println!(
-                    "Found address: {} at xpub/{}, receive address {}",
-                    address, xpath_path_string, receive_address
-                );
-                state_handler.new_found();
-                return;
-            }
-            None => {}
-        }
-    }
-
-    state_handler.new_generated();
-}
-
-fn setup_logger_thread(
-    global_generated_counter: Arc<AtomicUsize>,
-    global_found_counter: Arc<AtomicUsize>,
-    running: Arc<AtomicBool>,
-) -> thread::JoinHandle<()> {
-    thread::spawn(move || {
-        let state_handler = StateHandler::new(
-            Arc::clone(&global_generated_counter),
-            Arc::clone(&global_found_counter),
-            running,
-            THREADS_BATCH_SIZE,
-        );
-
-        for _ in 0..WAIT_TIME_FOR_INITIAL_HASHRATE {
-            thread::sleep(Duration::from_secs(1));
-            if !state_handler.is_running() {
-                return;
-            }
-        }
-        let hashrate = state_handler.get_hashrate();
-        println!("INITIAL HASHRATE");
-        println!("{:.2} addresses/s", hashrate);
-
-        while state_handler.is_running() {
-            let (generated, found, run_time, hashrate) = state_handler.get_statistics();
-            println!(
-                "{} addresses generated, {} addresses found, {:.0} seconds, {:.2} addresses/s",
-                generated, found, run_time, hashrate
-            );
-            thread::sleep(STATUS_UPDATE_INTERVAL);
-        }
-    })
-}
-
-fn setup_worker_threads(
-    xpub: String,
-    prefix: String,
-    max_depth: u32,
-    num_threads: usize,
-    global_generated_counter: Arc<AtomicUsize>,
-    global_found_counter: Arc<AtomicUsize>,
-    running: Arc<AtomicBool>,
-) -> Vec<thread::JoinHandle<()>> {
-    let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(num_threads);
-    for _ in 0..num_threads {
-        let thread_xpub = xpub.clone();
-        let thread_prefix = prefix.clone();
-        let thread_max_depth = max_depth;
-        let thread_global_generated_counter = Arc::clone(&global_generated_counter);
-        let thread_global_found_counter = Arc::clone(&global_found_counter);
-        let thread_running = Arc::clone(&running);
-
-        let handle = thread::spawn(move || {
-            setup_worker_thread(
-                thread_xpub,
-                thread_prefix,
-                thread_max_depth,
-                thread_global_generated_counter,
-                thread_global_found_counter,
-                thread_running,
-            );
-        });
-        handles.push(handle);
-    }
-    handles
-}
-
-fn setup_threads(
-    xpub: String,
-    prefix: String,
-    max_depth: u32,
-    num_threads: usize,
-) -> (thread::JoinHandle<()>, Vec<thread::JoinHandle<()>>) {
-    let global_generated_counter = Arc::new(AtomicUsize::new(0));
-    let global_found_counter = Arc::new(AtomicUsize::new(0));
-    let running = Arc::new(AtomicBool::new(true));
-
-    // Spawn status update thread
-    let status_handle = setup_logger_thread(
-        Arc::clone(&global_generated_counter),
-        Arc::clone(&global_found_counter),
-        Arc::clone(&running),
-    );
-
-    // Spawn worker threads
-    let worker_handles = setup_worker_threads(
-        xpub,
-        prefix,
-        max_depth,
-        num_threads,
-        Arc::clone(&global_generated_counter),
-        Arc::clone(&global_found_counter),
-        Arc::clone(&running),
-    );
-
-    (status_handle, worker_handles)
-}
-
-fn main() {
+fn main() -> Result<(), String> {
     let cli = Cli::parse_args();
     let num_threads = thread::available_parallelism()
         .map(|p| p.get())
@@ -175,13 +26,32 @@ fn main() {
         "Starting vanity address search with {} threads...",
         num_threads
     );
+    let max_depth = cli.max_depth;
+    let xpub = cli.xpub;
+    let prefix = cli.prefix;
 
-    let (logger_handle, worker_handles) =
-        setup_threads(cli.xpub, cli.prefix, cli.max_depth, num_threads);
+    let xpub_deriver = ExtendedPublicKeyDeriver::new(&xpub);
 
-    for handle in worker_handles {
-        handle.join().unwrap();
+    let init = Instant::now();
+    let n = 40000;
+    let initial_path = vec![rand::random::<u32>() & 0x7FFFFFFF];
+    let vanity_address = VanityAddress::new(&prefix);
+
+    let mut xpub_path_walker = ExtendedPublicKeyPathWalker::new(initial_path, max_depth);
+    for _ in 0..10 {
+        let xpaths = xpub_path_walker.get_n_next_paths(n);
+        let pubkey_hashes = xpub_deriver.get_pubkeys_hash_160(&xpaths)?;
+        for pubkey_hash in pubkey_hashes {
+            match vanity_address.get_vanity_address(pubkey_hash) {
+                Some(address) => {
+                    println!("Found vanity address: {:?}", address);
+                }
+                None => {}
+            }
+        }
     }
 
-    logger_handle.join().unwrap();
+    let finished = Instant::now();
+    println!("Time taken: {:?}", finished.duration_since(init));
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,63 +9,180 @@ use cli::Cli;
 use extended_public_key_deriver::ExtendedPublicKeyDeriver;
 use extended_public_key_path_walker::ExtendedPublicKeyPathWalker;
 use rand;
+use state_handler::StateHandler;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use vanity_address::VanityAddress;
 
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
-const THREADS_BATCH_SIZE: usize = 1000;
-const WAIT_TIME_FOR_INITIAL_HASHRATE: u8 = 5;
+const THREADS_BATCH_SIZE: usize = 400000;
+const WAIT_TIME_FOR_INITIAL_HASHRATE: u8 = 30;
 
-fn main() -> Result<(), String> {
-    let cli = Cli::parse_args();
-    let num_threads = thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(4);
-    println!(
-        "Starting vanity address search with {} threads...",
-        num_threads
-    );
-    let max_depth = cli.max_depth;
-    let xpub = cli.xpub;
-    let prefix = cli.prefix;
-
-    let xpub_deriver = ExtendedPublicKeyDeriver::new(&xpub)?;
-
-    let init = Instant::now();
-    let n = 400000;
+fn setup_worker_thread(
+    xpub: String,
+    prefix: String,
+    max_depth: u32,
+    global_generated_counter: Arc<AtomicUsize>,
+    global_found_counter: Arc<AtomicUsize>,
+    running: Arc<AtomicBool>,
+) -> Result<(), String> {
     let initial_path = vec![rand::random::<u32>() & 0x7FFFFFFF];
-    let vanity_address = VanityAddress::new(&prefix);
-
     let mut xpub_path_walker = ExtendedPublicKeyPathWalker::new(initial_path, max_depth);
-    for _ in 0..10 {
-        let init = Instant::now();
-        let xpaths = xpub_path_walker.get_n_next_paths(n);
-        let fdjinal = Instant::now();
-        println!(
-            "Time taken to get {} paths: {:?}",
-            n,
-            fdjinal.duration_since(init)
-        );
+    let xpub_deriver = ExtendedPublicKeyDeriver::new(&xpub)?;
+    let vanity_address = VanityAddress::new(&prefix);
+    let mut state_handler = StateHandler::new(
+        Arc::clone(&global_generated_counter),
+        Arc::clone(&global_found_counter),
+        running,
+        THREADS_BATCH_SIZE,
+    );
+
+    while state_handler.is_running() {
+        let xpaths = xpub_path_walker.get_n_next_paths(THREADS_BATCH_SIZE);
         let pubkey_hashes = xpub_deriver.get_pubkeys_hash_160(&xpaths)?;
-        let init_with_pubkeys = Instant::now();
+
         for (i, pubkey_hash) in pubkey_hashes.iter().enumerate() {
+            if !state_handler.is_running() {
+                return Ok(());
+            }
+            state_handler.new_generated();
+
             match vanity_address.get_vanity_address(*pubkey_hash) {
                 Some(address) => {
-                    println!("Found vanity address {} at path {:?}", address, xpaths[i]);
+                    let xpath_path_string = xpaths[i]
+                        .iter()
+                        .take(xpaths[i].len().saturating_sub(2))
+                        .map(|p| p.to_string())
+                        .collect::<Vec<String>>()
+                        .join("/");
+                    let receive_address = xpaths[i][xpaths[i].len() - 1];
+                    println!(
+                        "Found address: {} at xpub/{}, receive address {}",
+                        address, xpath_path_string, receive_address
+                    );
+                    state_handler.new_found();
                 }
                 None => {}
             }
         }
-        let finished_with_pubkeys = Instant::now();
-        println!(
-            "Time taken to test {} pubkeys: {:?}",
-            n,
-            finished_with_pubkeys.duration_since(init_with_pubkeys)
-        );
     }
-
-    let finished = Instant::now();
-    println!("Time taken: {:?}", finished.duration_since(init));
     Ok(())
+}
+
+fn setup_logger_thread(
+    global_generated_counter: Arc<AtomicUsize>,
+    global_found_counter: Arc<AtomicUsize>,
+    running: Arc<AtomicBool>,
+    prefix: String,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let state_handler = StateHandler::new(
+            Arc::clone(&global_generated_counter),
+            Arc::clone(&global_found_counter),
+            running,
+            THREADS_BATCH_SIZE,
+        );
+
+        let mut wait_time = WAIT_TIME_FOR_INITIAL_HASHRATE;
+        let time_first_message = Duration::from_secs(2);
+        let time_second_message = Duration::from_secs(2);
+        let time_third_message = Duration::from_secs(1);
+        let time_fourth_message = Duration::from_secs(1);
+
+        // First message
+        if !state_handler.is_running() {
+            return;
+        }
+        println!("👨‍🎨: Hmmm, \"{}\" you say?", prefix);
+        thread::sleep(time_first_message);
+        wait_time -= time_first_message.as_secs() as u8;
+
+        if !state_handler.is_running() {
+            return;
+        }
+        // Second message
+        println!("👨‍🎨: What an interesting prefix!");
+        thread::sleep(time_second_message);
+        wait_time -= time_second_message.as_secs() as u8;
+        if !state_handler.is_running() {
+            return;
+        }
+
+        // third message
+        println!("👨‍🎨: Ok, lets do it!");
+        thread::sleep(time_third_message);
+        wait_time -= time_third_message.as_secs() as u8;
+
+        if !state_handler.is_running() {
+            return;
+        }
+
+        // fourth message
+        print!(
+            "👨‍🎨: Just wait here for {} seconds, I will prepare the studio",
+            wait_time
+        );
+        thread::sleep(time_fourth_message);
+
+        for _ in 0..wait_time {
+            thread::sleep(Duration::from_secs(1));
+            if !state_handler.is_running() {
+                return;
+            }
+            print!(".");
+            io::stdout().flush().unwrap();
+        }
+        println!();
+        let hashrate = state_handler.get_hashrate();
+        println!("INITIAL HASHRATE");
+        println!("{:.2} addresses/s", hashrate);
+
+        while state_handler.is_running() {
+            let (generated, found, run_time, hashrate) = state_handler.get_statistics();
+            println!(
+                "{} addresses generated, {} addresses found, {:.0} seconds, {:.2} addresses/s",
+                generated, found, run_time, hashrate
+            );
+            thread::sleep(STATUS_UPDATE_INTERVAL);
+        }
+    })
+}
+
+fn main() {
+    let cli = Cli::parse_args();
+    let global_generated_counter = Arc::new(AtomicUsize::new(0));
+    let global_found_counter = Arc::new(AtomicUsize::new(0));
+    let running = Arc::new(AtomicBool::new(true));
+
+    // Spawn logger thread
+    let logger_handle = setup_logger_thread(
+        Arc::clone(&global_generated_counter),
+        Arc::clone(&global_found_counter),
+        Arc::clone(&running),
+        cli.prefix.clone(),
+    );
+
+    // Spawn single worker thread
+    let worker_handle = {
+        let thread_running = Arc::clone(&running);
+        thread::spawn(move || {
+            if let Err(e) = setup_worker_thread(
+                cli.xpub,
+                cli.prefix,
+                cli.max_depth,
+                global_generated_counter,
+                global_found_counter,
+                thread_running,
+            ) {
+                eprintln!("Worker thread error: {}", e);
+            }
+        })
+    };
+
+    // Wait for worker to finish
+    worker_handle.join().unwrap();
+    logger_handle.join().unwrap();
 }

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -30,7 +30,7 @@ impl StateHandler {
 
     pub fn new_generated(&mut self) {
         self.generated_local += 1;
-        if self.generated_local == self.local_batch_size {
+        if self.generated_local >= self.local_batch_size {
             self.flush_generated();
         }
     }

--- a/src/vanity_address.rs
+++ b/src/vanity_address.rs
@@ -135,8 +135,6 @@ impl VanityAddress {
                 break;
             }
         }
-        println!("final_pattern: {:?}", final_pattern);
-
         final_pattern
     }
 

--- a/src/vanity_address.rs
+++ b/src/vanity_address.rs
@@ -1,28 +1,173 @@
 use crate::bitcoin_address_helper::BitcoinAddressHelper;
-
+use std::collections::HashSet;
 pub struct VanityAddress {
+    pattern: Vec<u8>,
     prefix: String,
     bitcoin_address_helper: BitcoinAddressHelper,
 }
 
 impl VanityAddress {
     pub fn new(prefix: &str) -> Self {
-        VanityAddress {
+        let mut vanity = VanityAddress {
+            pattern: Vec::new(),
             prefix: prefix.to_string(),
             bitcoin_address_helper: BitcoinAddressHelper::new(),
-        }
+        };
+        vanity.pattern = vanity.get_pattern(prefix.to_string());
+        vanity
     }
 
     pub fn get_vanity_address(&self, pubkey_hash: [u8; 20]) -> Option<String> {
-        let address_with_fake_checksum = self
-            .bitcoin_address_helper
-            .get_address_with_fake_checksum(pubkey_hash);
-        if address_with_fake_checksum.starts_with(&self.prefix) {
-            let real_address = self
+        if self.match_pattern(pubkey_hash) {
+            let address_with_fake_checksum = self
                 .bitcoin_address_helper
-                .get_address_from_pubkey_hash(pubkey_hash);
-            return Some(real_address);
+                .get_address_with_fake_checksum(pubkey_hash);
+            if address_with_fake_checksum.starts_with(&self.prefix) {
+                let real_address = self
+                    .bitcoin_address_helper
+                    .get_address_from_pubkey_hash(pubkey_hash);
+                return Some(real_address);
+            }
         }
         None
+    }
+
+    fn match_pattern(&self, pubkey_hash: [u8; 20]) -> bool {
+        if self.pattern.len() == 1 {
+            return true; // all addresses are valid. Skip pattern recognition
+        }
+        for i in 0..self.pattern.len() {
+            if pubkey_hash[i] != self.pattern[i] {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn get_pattern(&self, prefix: String) -> Vec<u8> {
+        if prefix.len() == 1 {
+            // all addresses are valid. Skip the pattern search
+            println!("to aqui");
+            return vec![0x00];
+        }
+
+        let prefix_len = prefix.len();
+        let mut pubkey_hashs: Vec<[u8; 20]> = Vec::new();
+
+        // prefix + ones + zeros
+        for address_len in 26..=35 {
+            for ones in 0..=address_len - prefix_len {
+                let address = prefix.as_str().to_owned()
+                    + &"1".repeat(ones)
+                    + &"z".repeat(address_len - prefix_len - ones);
+                let pubkey_hash = self
+                    .bitcoin_address_helper
+                    .get_pubkey_hash_from_address(address);
+                if pubkey_hash.is_some() {
+                    pubkey_hashs.push(pubkey_hash.unwrap());
+                }
+            }
+        }
+
+        // prefix + zeros + ones
+        for address_len in 26..=35 {
+            for zs in 0..=address_len - prefix_len {
+                let address = prefix.as_str().to_owned()
+                    + &"z".repeat(zs)
+                    + &"1".repeat(address_len - prefix_len - zs);
+                let pubkey_hash = self
+                    .bitcoin_address_helper
+                    .get_pubkey_hash_from_address(address);
+                if pubkey_hash.is_some() {
+                    pubkey_hashs.push(pubkey_hash.unwrap());
+                }
+            }
+        }
+
+        let extended_prefix_length: usize = 3;
+        let extended_prefix_combinations: Vec<String> =
+            Self::get_all_base58_combinations(extended_prefix_length);
+
+        // prefix + extended_prefix + ones
+        for address_len in 26..=35 {
+            for extended_prefix in extended_prefix_combinations.iter() {
+                let address = prefix.as_str().to_owned()
+                    + extended_prefix
+                    + &"1".repeat(address_len - prefix_len - extended_prefix_length);
+                let pubkey_hash = self
+                    .bitcoin_address_helper
+                    .get_pubkey_hash_from_address(address);
+                if pubkey_hash.is_some() {
+                    pubkey_hashs.push(pubkey_hash.unwrap());
+                }
+            }
+        }
+
+        // prefix + extended_prefix + zs
+        for address_len in 26..=35 {
+            for extended_prefix in extended_prefix_combinations.iter() {
+                let address = prefix.as_str().to_owned()
+                    + extended_prefix
+                    + &"z".repeat(address_len - prefix_len - extended_prefix_length);
+                let pubkey_hash = self
+                    .bitcoin_address_helper
+                    .get_pubkey_hash_from_address(address);
+                if pubkey_hash.is_some() {
+                    pubkey_hashs.push(pubkey_hash.unwrap());
+                }
+            }
+        }
+
+        if pubkey_hashs.len() < 2 {
+            return vec![];
+        }
+
+        let mut final_pattern: Vec<u8> = Vec::new();
+        for i in 0..=20 {
+            let mut pattern_for_this_index: HashSet<Vec<u8>> = HashSet::new();
+            for pubkey_hash in pubkey_hashs.iter() {
+                let first_n_bytes = pubkey_hash.iter().take(i).cloned().collect::<Vec<u8>>();
+                pattern_for_this_index.insert(first_n_bytes);
+            }
+            if pattern_for_this_index.len() == 1 {
+                final_pattern = pattern_for_this_index.iter().next().unwrap().clone();
+            } else {
+                break;
+            }
+        }
+        println!("final_pattern: {:?}", final_pattern);
+
+        final_pattern
+    }
+
+    fn get_all_base58_combinations(n: usize) -> Vec<String> {
+        let base58_chars = [
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H",
+            "J", "K", "L", "M", "N", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a",
+            "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "m", "n", "o", "p", "q", "r", "s",
+            "t", "u", "v", "w", "x", "y", "z",
+        ];
+
+        fn generate_combinations(
+            chars: &[&str],
+            current: String,
+            length: usize,
+            result: &mut Vec<String>,
+        ) {
+            if length == 0 {
+                result.push(current);
+                return;
+            }
+
+            for &c in chars {
+                let mut new_str = current.clone();
+                new_str.push_str(c);
+                generate_combinations(chars, new_str, length - 1, result);
+            }
+        }
+
+        let mut result = Vec::new();
+        generate_combinations(&base58_chars, String::new(), n, &mut result);
+        result
     }
 }


### PR DESCRIPTION
# A great experiment
The most resource-intensive part of the process is obtaining the public key hash from the xpub and path. Initially, we were using an infinite iterator to generate paths:

    Path -> PubKeyHash -> TestPrefix

This approach worked well, but the parallelism was handled at the top level of the tool. The main function was creating threads, each of which ran this operation.
## What was changed:

We refactored the process to handle multiple paths in batches, as follows:
```
loop {
get n paths instead of just one iterator (currently hardcoded for 400,000)
pass this vector to a function that applies the paths to the xpub (returns a vector of pubkey_hashes)
with the vector of pubkey_hashes, test all 400k pubkey_hashes and continue
}
```

This change works well in theory, but I encountered a few challenges:

**CPU Usage**: The CPU usage isn’t consistently at 100%. Due to how the threads merge into a worker thread, there’s some "bloat-time", causing CPU usage to fluctuate in waves. This happens because the work is divided, and some parts of it take longer than others.
![image](https://github.com/user-attachments/assets/f033d43c-29c4-4cc5-84f1-bdebe05bb594)

**Thread Synchronization**: There’s a slight delay when passing work to the threads. Any time the worker thread spends processing could cause other threads to be idle. However, this impact seems minimal because we introduced a new prefix filter based on the xpub. This filter efficiently reduces the number of xpubs before converting them to base58, significantly speeding up the prefix identification process.

### Good news:

Even with these fluctuations in CPU load, the results in terms of addresses per second are almost identical to the previous implementation. This suggests that with further optimizations, we can still squeeze more performance from the CPU.
## Why this change?

This refactor was primarily aimed at setting up different backends for deriving public keys from the xpub and path, with an eye toward hardware that supports large parallel processing capabilities (e.g., GPUs).

To do this, the plan is to implement a function that receives a list of backends from the extended public key derivation tool. Each backend will spawn its own thread, running independently using the updated approach:

```
loop {
get n paths instead of just one iterator (currently hardcoded for 400,000)
pass this vector to a function that applies the paths to the xpub (returns a vector of pubkey_hashes) ---- THIS PART WOULD CHANGE
with the vector of pubkey_hashes, test all 400k pubkey_hashes and continue
}
```

This change will allow for multiple backends to run in parallel, each with the same state, managed by a state handler. Logs will be unified, and overall workflow will be more modular.
Another improvement:

One important change I haven't mentioned yet: filtering pubkey_hashes without converting to base58. This is a major optimization. Previously, we were converting each potential pubkey_hash to base58 to check for a prefix, but with the new approach, we directly check for the prefix in the raw pubkey_hash. This eliminates the overhead of converting to base58, which speeds up the process considerably.
# What's next?

Although the implementation isn't fully complete—there's no formal interface for backends yet and some parts are still under development—this change marks an important step forward.

Next, I plan to test a new backend for this class using OpenGL and my trusty (or not-so-trusty) Intel Arc GPU.