### PR TITLE
release: v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "address-artisan"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "address-artisan"
-version = "0.4.0"
+version = "0.5.0"
 description = "Vanity Bitcoin address generator based on BIP32 extended public keys with GPU acceleration."
 authors = ["Marcus Lacerda <marcuslacerda@tutamail.com>"]
 readme = "README.md"

--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,0 +1,51 @@
+# Release v0.5.0 - August 7, 2026
+
+## 🎯 Highlights
+
+Address Artisan v0.5.0 brings the biggest GPU performance jump since GPU support was introduced: a completely new scalar multiplication method makes GPU search up to **4.6x faster** - from 13M to 60M addresses per second on an NVIDIA RTX 5090, and about 2x faster on Intel Arc.
+
+---
+
+## ✨ What's New
+
+### ⚡ New G times Scalar Method
+
+The core of the GPU search - multiplying the secp256k1 generator point by a scalar - was completely rewritten. Instead of the classic double-and-add ladder (256 point doublings plus additions per derivation), the new method uses precomputed lookup tables:
+
+- **32 tables of 256 points** (512 KB), computed once on the CPU at startup and uploaded once to GPU global memory
+- Each scalar multiplication is now just **32 point additions with zero doublings**
+- Works on **all GPU vendors**: the tables live in regular global memory, avoiding the 64 KB `__constant` limit that blocked the first attempt at this method (#80)
+
+**Performance:**
+
+| GPU | v0.4.0 | v0.5.0 |
+| --- | --- | --- |
+| NVIDIA RTX 5090 | 13M addr/s | **60M addr/s** |
+
+On an Intel Arc A350M the same change measured about **2x faster** search.
+
+**No configuration needed** - the speedup is automatic on any `--gpu` / `--gpu-only` run.
+
+---
+
+### 🔧 Under the Hood
+
+- **Rolled kernel loops**: unrolling the window loop crashed NVIDIA's NVVM compiler and bloated the generated code; keeping the loops rolled fixes NVIDIA support and is faster on every platform tested
+- **Point-at-infinity handling** in the mixed Jacobian + affine point addition, with dedicated tests
+- **New contributor benchmark**: measure raw CKDpub throughput on your GPU with `cargo test --release -- --ignored bench_ckdpub_throughput --nocapture`
+
+---
+
+## 📦 Installation
+
+Available as pre-built binaries, Debian packages, or via cargo. See the [README.md](https://github.com/seaasses/address-artisan#readme) for detailed installation instructions.
+
+**Quick install via cargo:**
+
+```bash
+cargo install address-artisan
+```
+
+---
+
+**⭐ If you find this useful, star the repo!**


### PR DESCRIPTION
v0.5.0

Release notes: [docs/release-notes/v0.5.0.md](https://github.com/seaasses/address-artisan/blob/release/v0.5.0/docs/release-notes/v0.5.0.md)