### PR TITLE
test: run the test harness single-threaded by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Run the test harness single-threaded by default.
+#
+# The OpenCL tests each build a heavy kernel program and allocate GPU buffers
+# (e.g. the g-tables). Running them in parallel makes several compile/allocate
+# at once, which flakily fails under GPU memory/resource pressure (especially
+# on a shared GPU) — surfacing as panics in the EC tests, not value mismatches.
+# Serializing avoids that. Override per-run with `cargo test -- --test-threads=N`
+# or `RUST_TEST_THREADS=N cargo test`.
+[env]
+RUST_TEST_THREADS = "1"


### PR DESCRIPTION
# Run the test harness single-threaded by default

## Why

Each OpenCL test builds its own (heavy) kernel program and allocates GPU buffers — notably the ~512 KB g-tables. With the default parallel test harness, many of these compile and allocate **at the same time**, which flakily fails under GPU memory/resource pressure — especially when the GPU is shared with another workload.

The failures surface as **panics in the EC tests** (`g_times_scalar`, `jacobian_*`, `jacobian_to_affine`, `compress_point`) at `.unwrap()` on program build / buffer allocation — **not** as value mismatches, and the failing set changes from run to run (non-deterministic). Run the same test alone and it passes.

## Change

Add `.cargo/config.toml` setting `RUST_TEST_THREADS = "1"` via the `[env]` table, so a plain `cargo test` serializes the harness. This drops the peak GPU resource use and removes the flakiness.

- Override per run when desired: `cargo test -- --test-threads=N` or `RUST_TEST_THREADS=N cargo test`.
- CPU-only tests are unaffected in correctness (just run serially; they are fast).

## Verification

On an RTX 5090, plain `cargo test` (no flag) over the previously-flaky `opencl::tests::secp256k1` module: **39 passed, 0 failed** in ~10s, repeatably. The full suite serialized: **388 passed, 0 failed, 2 ignored**.
