### PR TITLE
perf: NVIDIA inline-PTX carry-chain multiply (vendor-gated)

### DIFF
--- a/src/opencl/implementations/big_uint/big_uint_multiplication.cl
+++ b/src/opencl/implementations/big_uint/big_uint_multiplication.cl
@@ -1,17 +1,219 @@
 #include "src/opencl/headers/big_uint/big_uint_multiplication.cl.h"
 
+// 256x256 -> 512 multiply, big-limb-first (limbs[0] most significant).
+//
+// Two implementations, selected at OpenCL compile time:
+//   - NVIDIA (defines __NV_CL_C_VERSION, or forced with -D AA_USE_PTX): an
+//     operand-scanning multiply that chains the hardware carry flag through
+//     inline PTX (mad.lo.cc / madc.hi.cc / addc). This path is ported from
+//     BitCrack (brichard19/BitCrack, cudaMath/secp256k1.cuh + cudaMath/ptx.cuh),
+//     adapted to OpenCL inline asm and this codebase's big-limb-first Uint512.
+//   - Everything else (Intel Arc, CPU, ...): a portable Comba column-scan with a
+//     ulong accumulator. No inline asm.
+// Both produce the identical 512-bit product.
+
+#if defined(__NV_CL_C_VERSION) || defined(AA_USE_PTX)
+
+#define AA_mad_lo_cc(d, a, x, b)  asm volatile("mad.lo.cc.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(x), "r"(b))
+#define AA_madc_lo_cc(d, a, x, b) asm volatile("madc.lo.cc.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(x), "r"(b))
+#define AA_mad_hi_cc(d, a, x, b)  asm volatile("mad.hi.cc.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(x), "r"(b))
+#define AA_madc_hi_cc(d, a, x, b) asm volatile("madc.hi.cc.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(x), "r"(b))
+#define AA_madc_hi(d, a, x, b)    asm volatile("madc.hi.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(x), "r"(b))
+#define AA_addc(d, a, b)          asm volatile("addc.u32 %0, %1, %2;" : "=r"(d) : "r"(a), "r"(b))
+
+inline Uint512 uint256_multiplication(const Uint256 a, const Uint256 b)
+{
+    // Big-limb-first throughout: index 0 is the most significant 32-bit word.
+    // c[] accumulates the low 256 bits, high[] the high 256 bits.
+    uint c[8];
+    uint high[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    uint t;
+
+    // a[7] * b (low)
+    t = a.limbs[7];
+    for (int i = 7; i >= 0; i--)
+        c[i] = t * b.limbs[i];
+    // a[7] * b (high)
+    AA_mad_hi_cc(c[6], t, b.limbs[7], c[6]);
+    AA_madc_hi_cc(c[5], t, b.limbs[6], c[5]);
+    AA_madc_hi_cc(c[4], t, b.limbs[5], c[4]);
+    AA_madc_hi_cc(c[3], t, b.limbs[4], c[3]);
+    AA_madc_hi_cc(c[2], t, b.limbs[3], c[2]);
+    AA_madc_hi_cc(c[1], t, b.limbs[2], c[1]);
+    AA_madc_hi_cc(c[0], t, b.limbs[1], c[0]);
+    AA_madc_hi(high[7], t, b.limbs[0], high[7]);
+
+    // a[6] * b (low)
+    t = a.limbs[6];
+    AA_mad_lo_cc(c[6], t, b.limbs[7], c[6]);
+    AA_madc_lo_cc(c[5], t, b.limbs[6], c[5]);
+    AA_madc_lo_cc(c[4], t, b.limbs[5], c[4]);
+    AA_madc_lo_cc(c[3], t, b.limbs[4], c[3]);
+    AA_madc_lo_cc(c[2], t, b.limbs[3], c[2]);
+    AA_madc_lo_cc(c[1], t, b.limbs[2], c[1]);
+    AA_madc_lo_cc(c[0], t, b.limbs[1], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[0], high[7]);
+    AA_addc(high[6], high[6], 0);
+    // a[6] * b (high)
+    AA_mad_hi_cc(c[5], t, b.limbs[7], c[5]);
+    AA_madc_hi_cc(c[4], t, b.limbs[6], c[4]);
+    AA_madc_hi_cc(c[3], t, b.limbs[5], c[3]);
+    AA_madc_hi_cc(c[2], t, b.limbs[4], c[2]);
+    AA_madc_hi_cc(c[1], t, b.limbs[3], c[1]);
+    AA_madc_hi_cc(c[0], t, b.limbs[2], c[0]);
+    AA_madc_hi_cc(high[7], t, b.limbs[1], high[7]);
+    AA_madc_hi(high[6], t, b.limbs[0], high[6]);
+
+    // a[5] * b (low)
+    t = a.limbs[5];
+    AA_mad_lo_cc(c[5], t, b.limbs[7], c[5]);
+    AA_madc_lo_cc(c[4], t, b.limbs[6], c[4]);
+    AA_madc_lo_cc(c[3], t, b.limbs[5], c[3]);
+    AA_madc_lo_cc(c[2], t, b.limbs[4], c[2]);
+    AA_madc_lo_cc(c[1], t, b.limbs[3], c[1]);
+    AA_madc_lo_cc(c[0], t, b.limbs[2], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[1], high[7]);
+    AA_madc_lo_cc(high[6], t, b.limbs[0], high[6]);
+    AA_addc(high[5], high[5], 0);
+    // a[5] * b (high)
+    AA_mad_hi_cc(c[4], t, b.limbs[7], c[4]);
+    AA_madc_hi_cc(c[3], t, b.limbs[6], c[3]);
+    AA_madc_hi_cc(c[2], t, b.limbs[5], c[2]);
+    AA_madc_hi_cc(c[1], t, b.limbs[4], c[1]);
+    AA_madc_hi_cc(c[0], t, b.limbs[3], c[0]);
+    AA_madc_hi_cc(high[7], t, b.limbs[2], high[7]);
+    AA_madc_hi_cc(high[6], t, b.limbs[1], high[6]);
+    AA_madc_hi(high[5], t, b.limbs[0], high[5]);
+
+    // a[4] * b (low)
+    t = a.limbs[4];
+    AA_mad_lo_cc(c[4], t, b.limbs[7], c[4]);
+    AA_madc_lo_cc(c[3], t, b.limbs[6], c[3]);
+    AA_madc_lo_cc(c[2], t, b.limbs[5], c[2]);
+    AA_madc_lo_cc(c[1], t, b.limbs[4], c[1]);
+    AA_madc_lo_cc(c[0], t, b.limbs[3], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[2], high[7]);
+    AA_madc_lo_cc(high[6], t, b.limbs[1], high[6]);
+    AA_madc_lo_cc(high[5], t, b.limbs[0], high[5]);
+    AA_addc(high[4], high[4], 0);
+    // a[4] * b (high)
+    AA_mad_hi_cc(c[3], t, b.limbs[7], c[3]);
+    AA_madc_hi_cc(c[2], t, b.limbs[6], c[2]);
+    AA_madc_hi_cc(c[1], t, b.limbs[5], c[1]);
+    AA_madc_hi_cc(c[0], t, b.limbs[4], c[0]);
+    AA_madc_hi_cc(high[7], t, b.limbs[3], high[7]);
+    AA_madc_hi_cc(high[6], t, b.limbs[2], high[6]);
+    AA_madc_hi_cc(high[5], t, b.limbs[1], high[5]);
+    AA_madc_hi(high[4], t, b.limbs[0], high[4]);
+
+    // a[3] * b (low)
+    t = a.limbs[3];
+    AA_mad_lo_cc(c[3], t, b.limbs[7], c[3]);
+    AA_madc_lo_cc(c[2], t, b.limbs[6], c[2]);
+    AA_madc_lo_cc(c[1], t, b.limbs[5], c[1]);
+    AA_madc_lo_cc(c[0], t, b.limbs[4], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[3], high[7]);
+    AA_madc_lo_cc(high[6], t, b.limbs[2], high[6]);
+    AA_madc_lo_cc(high[5], t, b.limbs[1], high[5]);
+    AA_madc_lo_cc(high[4], t, b.limbs[0], high[4]);
+    AA_addc(high[3], high[3], 0);
+    // a[3] * b (high)
+    AA_mad_hi_cc(c[2], t, b.limbs[7], c[2]);
+    AA_madc_hi_cc(c[1], t, b.limbs[6], c[1]);
+    AA_madc_hi_cc(c[0], t, b.limbs[5], c[0]);
+    AA_madc_hi_cc(high[7], t, b.limbs[4], high[7]);
+    AA_madc_hi_cc(high[6], t, b.limbs[3], high[6]);
+    AA_madc_hi_cc(high[5], t, b.limbs[2], high[5]);
+    AA_madc_hi_cc(high[4], t, b.limbs[1], high[4]);
+    AA_madc_hi(high[3], t, b.limbs[0], high[3]);
+
+    // a[2] * b (low)
+    t = a.limbs[2];
+    AA_mad_lo_cc(c[2], t, b.limbs[7], c[2]);
+    AA_madc_lo_cc(c[1], t, b.limbs[6], c[1]);
+    AA_madc_lo_cc(c[0], t, b.limbs[5], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[4], high[7]);
+    AA_madc_lo_cc(high[6], t, b.limbs[3], high[6]);
+    AA_madc_lo_cc(high[5], t, b.limbs[2], high[5]);
+    AA_madc_lo_cc(high[4], t, b.limbs[1], high[4]);
+    AA_madc_lo_cc(high[3], t, b.limbs[0], high[3]);
+    AA_addc(high[2], high[2], 0);
+    // a[2] * b (high)
+    AA_mad_hi_cc(c[1], t, b.limbs[7], c[1]);
+    AA_madc_hi_cc(c[0], t, b.limbs[6], c[0]);
+    AA_madc_hi_cc(high[7], t, b.limbs[5], high[7]);
+    AA_madc_hi_cc(high[6], t, b.limbs[4], high[6]);
+    AA_madc_hi_cc(high[5], t, b.limbs[3], high[5]);
+    AA_madc_hi_cc(high[4], t, b.limbs[2], high[4]);
+    AA_madc_hi_cc(high[3], t, b.limbs[1], high[3]);
+    AA_madc_hi(high[2], t, b.limbs[0], high[2]);
+
+    // a[1] * b (low)
+    t = a.limbs[1];
+    AA_mad_lo_cc(c[1], t, b.limbs[7], c[1]);
+    AA_madc_lo_cc(c[0], t, b.limbs[6], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[5], high[7]);
+    AA_madc_lo_cc(high[6], t, b.limbs[4], high[6]);
+    AA_madc_lo_cc(high[5], t, b.limbs[3], high[5]);
+    AA_madc_lo_cc(high[4], t, b.limbs[2], high[4]);
+    AA_madc_lo_cc(high[3], t, b.limbs[1], high[3]);
+    AA_madc_lo_cc(high[2], t, b.limbs[0], high[2]);
+    AA_addc(high[1], high[1], 0);
+    // a[1] * b (high)
+    AA_mad_hi_cc(c[0], t, b.limbs[7], c[0]);
+    AA_madc_hi_cc(high[7], t, b.limbs[6], high[7]);
+    AA_madc_hi_cc(high[6], t, b.limbs[5], high[6]);
+    AA_madc_hi_cc(high[5], t, b.limbs[4], high[5]);
+    AA_madc_hi_cc(high[4], t, b.limbs[3], high[4]);
+    AA_madc_hi_cc(high[3], t, b.limbs[2], high[3]);
+    AA_madc_hi_cc(high[2], t, b.limbs[1], high[2]);
+    AA_madc_hi(high[1], t, b.limbs[0], high[1]);
+
+    // a[0] * b (low)
+    t = a.limbs[0];
+    AA_mad_lo_cc(c[0], t, b.limbs[7], c[0]);
+    AA_madc_lo_cc(high[7], t, b.limbs[6], high[7]);
+    AA_madc_lo_cc(high[6], t, b.limbs[5], high[6]);
+    AA_madc_lo_cc(high[5], t, b.limbs[4], high[5]);
+    AA_madc_lo_cc(high[4], t, b.limbs[3], high[4]);
+    AA_madc_lo_cc(high[3], t, b.limbs[2], high[3]);
+    AA_madc_lo_cc(high[2], t, b.limbs[1], high[2]);
+    AA_madc_lo_cc(high[1], t, b.limbs[0], high[1]);
+    AA_addc(high[0], high[0], 0);
+    // a[0] * b (high)
+    AA_mad_hi_cc(high[7], t, b.limbs[7], high[7]);
+    AA_madc_hi_cc(high[6], t, b.limbs[6], high[6]);
+    AA_madc_hi_cc(high[5], t, b.limbs[5], high[5]);
+    AA_madc_hi_cc(high[4], t, b.limbs[4], high[4]);
+    AA_madc_hi_cc(high[3], t, b.limbs[3], high[3]);
+    AA_madc_hi_cc(high[2], t, b.limbs[2], high[2]);
+    AA_madc_hi_cc(high[1], t, b.limbs[1], high[1]);
+    AA_madc_hi(high[0], t, b.limbs[0], high[0]);
+
+    Uint512 r;
+#pragma unroll
+    for (int k = 0; k < 8; k++)
+    {
+        r.limbs[k] = high[k];     // upper 256 bits
+        r.limbs[8 + k] = c[k];    // lower 256 bits
+    }
+    return r;
+}
+
+#undef AA_mad_lo_cc
+#undef AA_madc_lo_cc
+#undef AA_mad_hi_cc
+#undef AA_madc_hi_cc
+#undef AA_madc_hi
+#undef AA_addc
+
+#else // portable path (Intel Arc, CPU, non-NVIDIA)
+
 // Schoolbook (Comba / column-scanning) 256x256 -> 512 multiply with 8x32-bit
 // limbs. Each partial product a[i]*b[j] is a native 32x32 -> 64 multiply.
-//
-// Big-limb-first layout: limbs[0] is most significant. Term a[i]*b[j] has
-// weight 2^(32*(14-i-j)), so it lands in output column s = i+j (LSW-first),
-// i.e. output word r.limbs[15 - s]. Columns run s = 0..14; the top output
-// word (r.limbs[0], position 15) only receives the carry-out of column 14.
-//
-// A column sums up to 8 products, each < 2^64, so the running total is < 2^67.
-// It is held in a 64-bit accumulator `acc` plus a `uint acc_carry` counting
-// 2^64 wraps (<= 8). Between columns the value is shifted down 32 bits as
-// (acc >> 32) | (acc_carry << 32) < 2^35.
+// Term a[i]*b[j] lands in output column s = i+j (LSW-first) -> r.limbs[15 - s].
+// A column sums up to 8 products < 2^64 -> < 2^67, held in a 64-bit accumulator
+// plus a uint carry counting 2^64 wraps.
 inline Uint512 uint256_multiplication(const Uint256 a, const Uint256 b)
 {
     Uint512 r;
@@ -39,3 +241,5 @@ inline Uint512 uint256_multiplication(const Uint256 a, const Uint256 b)
 
     return r;
 }
+
+#endif


### PR DESCRIPTION
# NVIDIA Inline-PTX Carry-Chain Multiply (vendor-gated)

## Performance

The portable multiply uses a `ulong` Comba accumulator with software carry counting. On NVIDIA we can instead chain the **hardware carry flag** through inline PTX (`mad.lo.cc.u32` / `madc.hi.cc.u32` / `addc`), an operand-scanning multiply — the pattern serious GPU secp256k1 tools use.

Measured on an RTX 5090, interleaved (same session / clock state) vs the portable path:

| Metric | portable | this PR (PTX) |
| --- | --- | --- |
| `bench_modular_multiplication` (isolated) | ~49 G modmul/s | **~84 G modmul/s (+72%)** |
| `bench_ckdpub_throughput` | ~85.3 M keys/s | **~103.4 M keys/s (+21%)** |

Unlike the dedicated-square experiment (which measured flat because the compiler already CSEs `mul(a,a)`), this is a real win — the compiler does not derive the carry-flag chain from the `ulong` Comba on its own.

## Change

`src/opencl/implementations/big_uint/big_uint_multiplication.cl` now has two paths, chosen at OpenCL compile time:

- **NVIDIA** (`__NV_CL_C_VERSION` predefined by NVIDIA's OpenCL, or `-D AA_USE_PTX`): the inline-PTX operand-scanning multiply, producing the big-limb-first `Uint512`. Ported from **BitCrack** (brichard19/BitCrack, `cudaMath/secp256k1.cuh` + `cudaMath/ptx.cuh`), adapted to OpenCL inline asm and this codebase's layout (credited in the source).
- **Everything else** (Intel Arc, CPU, ...): the existing portable `ulong`-Comba, unchanged, moved into the `#else`.

No Rust changes — the gate is a compile-time macro, so it applies uniformly to the production build and every test harness. Only the multiply changed; the reduction stays portable (a follow-up can PTX it and measure the increment).

## Testing

- Full suite on RTX 5090 (takes the PTX path): **388 passed, 0 failed** (serialized). Includes the multiply boundary vectors, `modular_inverse` (255 squarings via `mul(a,a)`), the BIP32 `ckdpub` vectors, and `batch_address_search` vs CPU.
- **Please verify on Intel Arc:** the `#else` path is the current portable code unchanged, but I could not run it on Arc. A plain `cargo test` on an Arc device confirms `__NV_CL_C_VERSION` is not defined there (so it takes the portable path) and stays green.

## Next Steps

- PTX the reduction fold (same carry-chain style), measured on its own.
